### PR TITLE
Update logic when handle Table and List and Fix data type issue in RenderOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Simple Custom Markdown Converter
+# Simple Customize Markdown Converter
 This simple library help you convert Markdown to HTML and customize it.
 
 ## Feature

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-customize-markdown-converter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-customize-markdown-converter",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-customize-markdown-converter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert Markdown to your customize HTML",
   "keywords": [
     "markdown",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -247,13 +247,13 @@ export class Parser {
 
         const parseCell = (): TableCell => {
             const cellStartToken = this.peek()
-            if (cellStartToken?.type !== "CellStart") return { align: "left", chlidren: [] }
+            if (cellStartToken?.type !== "CellStart") return { align: "left", children: [] }
 
             this.next() // skip CellStart token
             const childrens = this.parseInlineUntil("CellEnd")
             return {
                 align: cellStartToken.align,
-                chlidren: childrens
+                children: childrens
             }
         }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -188,10 +188,7 @@ export class Parser {
                 break
             }
 
-            children.push({
-                type: "Paragraph",
-                children: this.parseInlineUntil("NewLine")
-            })
+            children.push(... this.parseInlineUntil("NewLine"))
         }
 
         return currentToken?.type === "TaskItem" ? {
@@ -256,7 +253,7 @@ export class Parser {
             const childrens = this.parseInlineUntil("CellEnd")
             return {
                 align: cellStartToken.align,
-                chlidren: [{ type: "Paragraph", children: childrens }]
+                chlidren: childrens
             }
         }
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,5 @@
 import { Node, TableRow } from "./types/node"
-import { RenderOption } from "./types/renderOptions"
+import { RenderElements, RenderOption } from "./types/renderOptions"
 
 export default class Renderer {
     option: RenderOption
@@ -14,7 +14,7 @@ export default class Renderer {
      * @param node - The abstract syntax tree (AST) from the Parser
      * @returns The rendered HTML string.
      */
-    render(node: Node): string {
+    render<K extends Node["type"]>(node: Extract<Node, { type: K }>): string {
         //Get proper handler type
         const handler = this.handleRender(node.type)
         //If node have children, recursive to handle all node's children
@@ -22,8 +22,8 @@ export default class Renderer {
         return handler(node, children)
     }
 
-    private handleRender(type: Node["type"]): (node: any, children: string[]) => string {
-        const defaultRender: Record<Node["type"], (node: any, children: string[]) => string> = {
+    private handleRender<K extends Node["type"]>(type: K): NonNullable<RenderElements[K]> {
+        const defaultRender: RenderElements = {
             //Base structural nodes
             Document: (_node, children) => children.join(""),
             Paragraph: (_node, children) => `<p>${children.join("")}</p>`,
@@ -57,7 +57,7 @@ export default class Renderer {
             Table: (node, children) => this.renderTable(node, children),
         }
 
-        return this.option.elements?.[type] ?? defaultRender[type]
+        return (this.option.elements?.[type] ?? defaultRender[type])!
     }
 
     private renderTable(node: Node, children: string[]) {
@@ -69,7 +69,7 @@ export default class Renderer {
                 const tag = row.isHeader ? "th" : "td"
                 const cells = row.cells.map(cell => {
                     const align = `style="text-align:${cell.align}"`
-                    return `<${tag} ${align}>${cell.chlidren.map(c => this.render(c)).join("")}</${tag}>`
+                    return `<${tag} ${align}>${cell.children.map(c => this.render(c)).join("")}</${tag}>`
                 }).join("")
 
                 return `<tr>${cells}</tr>`

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -31,7 +31,7 @@ export default class Renderer {
             //Container nodes
             CodeBlock: (node) => `<pre><code class="lang-${node.lang}">${this.escapeHtml(node.content)}</code></pre>`,
             Header: (node, children) => `<h${node.level}${node.level <= 2 ? ' style="border-bottom: 1px solid #d1d9e0b3"' : ''}>${children.join("")}</h${node.level}>`,
-            Quote: (_node, children) => `<blockquote>${children.join("")}</blockquote>`,
+            Quote: (_node, children) => `<blockquote style="margin:0; padding:0 1em; color:#59636e; border-left:.25em solid #d1d9e0;">${children.join("")}</blockquote>`,
 
             //For list nodes
             List: (node, children) => node.ordered ? `<ol>${children.join("")}</ol>` : `<ul>${children.join("")}</ul>`,

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -49,5 +49,5 @@ export type TableRow = {
 
 export type TableCell = {
     align: "left" | "center" | "right",
-    chlidren: Node[]
+    children: Node[]
 }

--- a/src/types/renderOptions.ts
+++ b/src/types/renderOptions.ts
@@ -1,11 +1,32 @@
 import { Node } from "./node"
 
 /**
- * Option to customize how AST nodes are renderes into HTML
+ * Function type for rendering an AST node to HTML.
  * 
- * @property elements? - A mapping of AST node types to custom render functions.
- * - The key is the `Node` type (e.g. `"Header"`, `"Text"`).
- * - The value is a function `(node, children) => string` that define how to render HTML string. With `node` is a AST `Node`. `children` is the node's childrens
+ * @template T - A subtype of `Node` corresponding to the render node
+ * @param node - The AST node to render
+ * @param children - Rendered HTML strings of the node's children
+ * @returns A HTML string representation of the node
+ */
+type NodeRenderer<T extends Node = Node> = (node: T, children: string[]) => string
+
+/**
+ * A mapping of AST node types to custom render functions.
+ * 
+ * - The key is a `Node["type"]` string literal (e.g. `"Header"`, `"Paragraph"`)
+ * - The value is a function `(node, children) => string`:
+ *      - `node` is a `Node` with its attribute depending on its `type`.
+ *      (e.g. `"Header"` nodes include `level`, `"CodeBlock"` nodes include `lang` and `content`, etc)
+ *      - `children` is the array of rendered strings of its children.
+ */
+export type RenderElements = {
+    [K in Node["type"]]?: NodeRenderer<Extract<Node, { type: K }>>
+}
+
+/**
+ * Options to customize how AST nodes are renderes into HTML
+ * 
+ * @property elements - Optional custom rendered for one or more node types
  * 
  * @example
  * ```ts
@@ -17,8 +38,7 @@ import { Node } from "./node"
  * }
  * ```
  * 
- * @todo Update`node` type in value function from `any` to `Node`
  */
 export type RenderOption = {
-    elements?: Partial<Record<Node["type"], (node: any, children: string[]) => string>>
+    elements?: RenderElements
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -24,52 +24,52 @@ This is a text
 This is also a text
 --\\-
 `
-        expect(convertMarkdownToHTML(md)).toBe('<h1 style=\"border-bottom: 1px solid #d1d9e0b3\">Hello everyone</h1><h4>Hello world</h4><p>This is a <strong>simple</strong> paragraph with a <a href="https://example.com">link</a> and some <code>inline code</code>.</p><blockquote><p> This is a blockquote.</p></blockquote><img src="image.png" alt="Alt text"/><pre><code class="lang-js">console.log("Hello World")</code></pre><p><s>justatext</s></p><p>*thisis*escape character</p><p>This is a text</p><hr><p>This is also a text</p><p>---</p>'
+        expect(convertMarkdownToHTML(md)).toBe('<h1 style=\"border-bottom: 1px solid #d1d9e0b3\">Hello everyone</h1><h4>Hello world</h4><p>This is a <strong>simple</strong> paragraph with a <a href="https://example.com">link</a> and some <code>inline code</code>.</p><blockquote style=\"margin:0; padding:0 1em; color:#59636e; border-left:.25em solid #d1d9e0;\"><p> This is a blockquote.</p></blockquote><img src="image.png" alt="Alt text"/><pre><code class="lang-js">console.log("Hello World")</code></pre><p><s>justatext</s></p><p>*thisis*escape character</p><p>This is a text</p><hr><p>This is also a text</p><p>---</p>'
         )
     })
 
 
     test("Test render list", () => {
         const md = "- Item 1\n- Item 2\n- Item 3"
-        expect(convertMarkdownToHTML(md)).toBe('<ul><li><p>Item 1</p></li><li><p>Item 2</p></li><li><p>Item 3</p></li></ul>')
+        expect(convertMarkdownToHTML(md)).toBe('<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>')
     })
 
     test("Test render nested list", () => {
         const md = "- Item 1\n  - Subitem 1.1\n  - Subitem 1.2\n- Item 2"
-        expect(convertMarkdownToHTML(md)).toBe('<ul><li><p>Item 1</p><ul><li><p>Subitem 1.1</p></li><li><p>Subitem 1.2</p></li></ul></li><li><p>Item 2</p></li></ul>')
+        expect(convertMarkdownToHTML(md)).toBe('<ul><li>Item 1<ul><li>Subitem 1.1</li><li>Subitem 1.2</li></ul></li><li>Item 2</li></ul>')
     })
 
     test("Test render 3-level nested list", () => {
         const md = "- Item 1\n  - Subitem 1.1\n    - Subsubitem 1.1.1\n  - Subitem 1.2\n- Item 2"
-        expect(convertMarkdownToHTML(md)).toBe("<ul><li><p>Item 1</p><ul><li><p>Subitem 1.1</p><ul><li><p>Subsubitem 1.1.1</p></li></ul></li><li><p>Subitem 1.2</p></li></ul></li><li><p>Item 2</p></li></ul>")
+        expect(convertMarkdownToHTML(md)).toBe("<ul><li>Item 1<ul><li>Subitem 1.1<ul><li>Subsubitem 1.1.1</li></ul></li><li>Subitem 1.2</li></ul></li><li>Item 2</li></ul>")
     })
 
     test("Test render nested ordered list", () => {
         const md = "1. Item 1\n   1. Subitem 1.1\n   2. Subitem 1.2\n2. Item 2"
         expect(convertMarkdownToHTML(md)).toBe(
-            "<ol><li><p>Item 1</p><ol><li><p>Subitem 1.1</p></li><li><p>Subitem 1.2</p></li></ol></li><li><p>Item 2</p></li></ol>"
+            "<ol><li>Item 1<ol><li>Subitem 1.1</li><li>Subitem 1.2</li></ol></li><li>Item 2</li></ol>"
         )
     })
 
     test("Test render mixed nested list", () => {
         const md = "- Item 1\n  1. Subitem 1.1\n  2. Subitem 1.2\n- Item 2"
         expect(convertMarkdownToHTML(md)).toBe(
-            '<ul><li><p>Item 1</p><ol><li><p>Subitem 1.1</p></li><li><p>Subitem 1.2</p></li></ol></li><li><p>Item 2</p></li></ul>'
+            '<ul><li>Item 1<ol><li>Subitem 1.1</li><li>Subitem 1.2</li></ol></li><li>Item 2</li></ul>'
         )
     })
 
     test("Render task list", () => {
         const md = "- [ ] Incomplete\n- [x] Complete"
         expect(convertMarkdownToHTML(md))
-            .toBe('<ul><li><input type="checkbox" disabled ><p>Incomplete</p></li><li><input type="checkbox" disabled checked><p>Complete</p></li></ul>')
+            .toBe('<ul><li><input type=\"checkbox\" disabled >Incomplete</li><li><input type=\"checkbox\" disabled checked>Complete</li></ul>')
     })
 
     test("Render table", () => {
         const md = "| Name  | Age |\n|-------|----:|\n| Alice |  24 |\n| Bob   |  30 |";
         expect(convertMarkdownToHTML(md)).toBe(
-            '<table><thead><tr><th style="text-align:left"><p>Name</p></th><th style="text-align:right"><p>Age</p></th></tr></thead>' +
-            '<tbody><tr><td style="text-align:left"><p>Alice</p></td><td style="text-align:right"><p>24</p></td></tr>' +
-            '<tr><td style=\"text-align:left"><p>Bob</p></td><td style="text-align:right"><p>30</p></td></tr></tbody></table>')
+            '<table><thead><tr><th style="text-align:left">Name</th><th style="text-align:right">Age</th></tr></thead>' +
+            '<tbody><tr><td style="text-align:left">Alice</td><td style="text-align:right">24</td></tr>' +
+            '<tr><td style=\"text-align:left">Bob</td><td style="text-align:right">30</td></tr></tbody></table>')
     })
 
     test("Basic customize render", () => {

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -136,22 +136,22 @@ describe("Parser", () => {
                     {
                         isHeader: true,
                         cells: [
-                            { align: "left", chlidren: [{ type: "Paragraph", children: [{ type: "Text", value: "Name" }] }] },
-                            { align: "right", chlidren: [{ type: "Paragraph", children: [{ type: "Text", value: "Age" }] }] },
+                            { align: "left", chlidren: [{ type: "Text", value: "Name" }] },
+                            { align: "right", chlidren: [{ type: "Text", value: "Age" }] },
                         ],
                     },
                     {
                         isHeader: false,
                         cells: [
-                            { align: "left", chlidren: [{ type: "Paragraph", children: [{ type: "Text", value: "Alice" }] }] },
-                            { align: "right", chlidren: [{ type: "Paragraph", children: [{ type: "Text", value: "24" }] }] },
+                            { align: "left", chlidren: [{ type: "Text", value: "Alice" }] },
+                            { align: "right", chlidren: [{ type: "Text", value: "24" }] },
                         ],
                     },
                     {
                         isHeader: false,
                         cells: [
-                            { align: "left", chlidren: [{ type: "Paragraph", children: [{ type: "Text", value: "Bob" }] }] },
-                            { align: "right", chlidren: [{ type: "Paragraph", children: [{ type: "Text", value: "30" }] }] },
+                            { align: "left", chlidren: [{ type: "Text", value: "Bob" }] },
+                            { align: "right", chlidren: [{ type: "Text", value: "30" }] },
                         ],
                     },
                 ]

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -136,22 +136,22 @@ describe("Parser", () => {
                     {
                         isHeader: true,
                         cells: [
-                            { align: "left", chlidren: [{ type: "Text", value: "Name" }] },
-                            { align: "right", chlidren: [{ type: "Text", value: "Age" }] },
+                            { align: "left", children: [{ type: "Text", value: "Name" }] },
+                            { align: "right", children: [{ type: "Text", value: "Age" }] },
                         ],
                     },
                     {
                         isHeader: false,
                         cells: [
-                            { align: "left", chlidren: [{ type: "Text", value: "Alice" }] },
-                            { align: "right", chlidren: [{ type: "Text", value: "24" }] },
+                            { align: "left", children: [{ type: "Text", value: "Alice" }] },
+                            { align: "right", children: [{ type: "Text", value: "24" }] },
                         ],
                     },
                     {
                         isHeader: false,
                         cells: [
-                            { align: "left", chlidren: [{ type: "Text", value: "Bob" }] },
-                            { align: "right", chlidren: [{ type: "Text", value: "30" }] },
+                            { align: "left", children: [{ type: "Text", value: "Bob" }] },
+                            { align: "right", children: [{ type: "Text", value: "30" }] },
                         ],
                     },
                 ]

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -85,7 +85,7 @@ describe("Renderer", () => {
             ]
         }
         const renderer = new Renderer({})
-        expect(renderer.render(node)).toBe("<blockquote><p>Hello?. This is a quote</p><p>And here is a quote too</p></blockquote>")
+        expect(renderer.render(node)).toBe("<blockquote style=\"margin:0; padding:0 1em; color:#59636e; border-left:.25em solid #d1d9e0;\"><p>Hello?. This is a quote</p><p>And here is a quote too</p></blockquote>")
     })
 
     test("Render link", () => {


### PR DESCRIPTION
## What's changed

### 1. Update logic when handing `Table` and `List`:
- Update `defaultRender` for `Blockquote` syntax: Now, it's have following CSS when render it:
```html
 <blockquote style="margin:0; padding:0 1em; color:#59636e; border-left:.25em solid #d1d9e0;"></blockquote>
``` 
- Update logic when handle `TableCell` and `ListItem/TaskItem`: It's not warp it's content inside a `<p>` anymore. 
- Update following test for `Blockquote`, `Table` and `List`.


### 2. Update renderOption:
- Change `node` data type in `RenderOption` by added `NodeRenderer` and `RenderElements` types.