### PR TITLE
Add handler for HTML syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-customize-markdown-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-customize-markdown-converter",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-customize-markdown-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Convert Markdown to your customize HTML",
   "keywords": [
     "markdown",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -55,6 +55,10 @@ export default class Renderer {
 
             //For table nodes
             Table: (node, children) => this.renderTable(node, children),
+
+            //For HTML
+            HTMLBlock: (node) => node.value,
+            HTMLInline: (node) => node.value
         }
 
         return (this.option.elements?.[type] ?? defaultRender[type])!

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -21,6 +21,9 @@
  * - Image: An image, with it's `src` and `alt`
  * - HorizontalLine: A horizontal line
  * - Text: Raw text content.
+ * - Table: A table, with it's rows
+ * - HTMLBlock: A HTML block element, with it's `value`
+ * - HTMLInline: An inline HTML element, with it's `value`
  */
 export type Node =
     | { type: "Document"; children: Node[] }
@@ -44,11 +47,21 @@ export type Node =
     | { type: "HTMLInline", value: string }
 
 
+/**
+ * A subtype represent a row of table
+ * @property isHeader - If this row is header
+ * @property cells: List cells of this row
+ */
 export type TableRow = {
     isHeader: boolean,
     cells: TableCell[]
 }
 
+/**
+ * A subtype represent a table cell
+ * @property align - Cell's align
+ * @property children - Cell's children nodes
+ */
 export type TableCell = {
     align: "left" | "center" | "right",
     children: Node[]

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -40,6 +40,8 @@ export type Node =
     | { type: "HorizontalLine" }
     | { type: "Text"; value: string }
     | { type: "Table"; rows: TableRow[] }
+    | { type: "HTMLBlock", value: string }
+    | { type: "HTMLInline", value: string }
 
 
 export type TableRow = {

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -21,6 +21,14 @@
  * - Image: An image (`![alt](url)`)
  * - HorizontalLine: A horizontal line (`---` or `___` or `***`)
  * - Text: Plain text content.
+ * - TableStart: Start of a table
+ * - TableEnd: End of a table
+ * - RowStart: Start of a table row
+ * - RowEnd: End of a table row
+ * - CellStart: Start of a table cell, with it's align accroding to it's row
+ * - CellEnd: End of a table cell
+ * - HTMLBlock: A HTML block element
+ * - HTMLInline: An inline HTML element
  * - EOF: A special token, this is the end of input.
  */
 export type Token =
@@ -40,7 +48,6 @@ export type Token =
     | { type: "Image", src: string, alt: string }
     | { type: "HorizontalLine" }
     | { type: "Text", value: string }
-    | { type: "EOF" }
     | { type: "TableStart" }
     | { type: "TableEnd" }
     | { type: "RowStart", isHeader: boolean }
@@ -49,3 +56,4 @@ export type Token =
     | { type: "CellEnd" }
     | { type: "HTMLBlock", value: string }
     | { type: "HTMLInline", value: string }
+    | { type: "EOF" }

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -47,3 +47,5 @@ export type Token =
     | { type: "RowEnd" }
     | { type: "CellStart", align: "left" | "center" | "right" }
     | { type: "CellEnd" }
+    | { type: "HTMLBlock", value: string }
+    | { type: "HTMLInline", value: string }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -91,4 +91,9 @@ This is also a text
         const input = "# Title\nHello **World**"
         expect(convertMarkdownToHTML(input, renderOptions)).toBe('<h5 class="custom-h1">Title</h5><div class="paragraph">Hello <b class="bold-text">World</b></div>')
     })
+
+    test("Html render", () => {
+        const md = 'Hello\n<span style="color:blue">friend</span>, today is a <b>beautiful day</b> 😄<div align="center"><h2 style="color:green">🌿 Welcome to My Page 🌿</h2><p>This is an <span style="color:red">HTML block</span> that mixes inline.</p></div>'
+        expect(convertMarkdownToHTML(md)).toBe(`<p>Hello</p><p><span style="color:blue">friend</span>, today is a <b>beautiful day</b> 😄</p><div align="center"><h2 style="color:green">🌿 Welcome to My Page 🌿</h2><p>This is an <span style="color:red">HTML block</span> that mixes inline.</p></div>`);
+    })
 })


### PR DESCRIPTION
## What's changed
- Add handler for HTML syntax include: `HTMLBlock` and `HTMLInline`.
- Add missing document for `Table` and `HTML` token and node.