### PR TITLE
release: release v1.3.0 - Add plugin for custom syntax rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,85 @@ function App() {
 }
 
 ```
+
+## Plugin (v1.3.0+)
+You can create a plugin to define custom sytax rule handler
+- With default converter
+```ts
+import { DefaultMarkdownConverter } from 'simple-customize-markdown-converter';
+
+const emojiPlugin = createPlugin<string, React.ReactNode>(
+  "Emoji",
+  "inline",
+  {
+      match: (lexer) => lexer.peek() === ":",
+      emit: (lexer) => {
+        lexer.next();
+        const value = lexer.readUntil(":");
+        lexer.listToken.push({ type: "Emoji", value });
+      }
+  },
+  {
+    execute: (parser, token) => {
+      parser.next(1);
+      return { type: "Emoji", value: token.value };
+    }
+  },
+  {
+    render: (node) => React.createElement(
+      "span",
+      { className: `emoji emoji-${node.value}` },
+      "😲"
+    )
+  }
+);
+
+const converter = new DefaultMarkdownConverter({}, plugin).convert(input)
+```
+
+- With React converter
+```tsx
+import { MarkdownComponent } from 'simple-customize-markdown-converter/react';
+
+function App() {
+  const emojiPlugin = createPlugin<string, React.ReactNode>(
+    "Emoji",
+    "inline",
+    {
+        match: (lexer) => lexer.peek() === ":",
+          emit: (lexer) => {
+            lexer.next();
+            const value = lexer.readUntil(":");
+            lexer.listToken.push({ type: "Emoji", value });
+          }
+    },
+    {
+      execute: (parser, token) => {
+        parser.next(1);
+        return { type: "Emoji", value: token.value };
+      }
+    },
+    {
+      render: (node) => React.createElement(
+        "span",
+        { className: `emoji emoji-${node.value}` },
+        "😲"
+      )
+    }
+  );
+
+  return (
+    <MarkdownComponent 
+      content="Hello :omg: world"
+      className="md-body"
+      options=options
+      plugin=[emojiPlugin]
+    />
+  );
+}
+```
+
+
 ## Security
 By default, HTML tags in Markdown are escaped. To allow raw HTML, explicitly set `allowDangerousHtml: true` in `converterOptions`. Be sure only **enable** this for **trusted** content.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-customize-markdown-converter",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-customize-markdown-converter",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-customize-markdown-converter",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Transform Markdown into fully customizable HTML or React components.",
   "keywords": [
     "markdown",

--- a/src/core/lexer/handler.ts
+++ b/src/core/lexer/handler.ts
@@ -1,9 +1,8 @@
-import Lexer, { ILexer } from "."
-import { Token, TokenizerStrategy } from "../../types/token"
+import { TokenizerStrategy } from "../../types/token"
 import * as utils from "../../utilities/tokenizer-utils"
 
 const EscapeCharacterHandler: TokenizerStrategy = {
-    name: "EscapeCharacter",
+    type: "EscapeCharacter",
     match: (lex) => lex.peek() === "\\" && lex.peek(1) !== undefined,
     emit: (lex) => {
         lex.next(1);
@@ -12,13 +11,13 @@ const EscapeCharacterHandler: TokenizerStrategy = {
 }
 
 const CommentHandler: TokenizerStrategy = {
-    name: "Comment",
+    type: "Comment",
     match: (lex) => lex.startsWith("<!--"),
     emit: (lex) => lex.readUntilMatchString("-->", true)
 }
 
 const HtmlHandler: TokenizerStrategy = {
-    name: "HTML",
+    type: "HTML",
     match: (lex) => lex.peek() === "<",
     emit: (lex) => {
         //Handle comment
@@ -33,7 +32,7 @@ const HtmlHandler: TokenizerStrategy = {
 }
 
 const HorizontalLineHandler: TokenizerStrategy = {
-    name: "HorizontalLine",
+    type: "HorizontalLine",
     match: (lex) => /^([-*_])\1{2,}$/.test(lex.peekUntil("\n").trim()) && lex.getLastToken()?.type === "NewLine",
     emit: (lex) => {
         lex.next(2) //Skip two first characters, remain will be skiped after loop
@@ -43,7 +42,7 @@ const HorizontalLineHandler: TokenizerStrategy = {
 }
 
 const CodeBlockHandler: TokenizerStrategy = {
-    name: "CodeBlock",
+    type: "CodeBlock",
     match: (lex) => lex.startsWith("```"),
     emit: (lex) => {
         let lang = ""
@@ -69,7 +68,7 @@ const CodeBlockHandler: TokenizerStrategy = {
 }
 
 const BoldHandler: TokenizerStrategy = {
-    name: "Bold",
+    type: "Bold",
     match: (lex) => lex.startsWith("**"),
     emit: (lex) => {
         lex.listToken.push({ type: "Bold" })
@@ -78,7 +77,7 @@ const BoldHandler: TokenizerStrategy = {
 }
 
 const StrikethroughHandler: TokenizerStrategy = {
-    name: "Strikethrough",
+    type: "Strikethrough",
     match: (lex) => lex.startsWith("~~"),
     emit: (lex) => {
         lex.listToken.push({ type: "Strikethrough" })
@@ -88,7 +87,7 @@ const StrikethroughHandler: TokenizerStrategy = {
 
 // Footnote
 const FootnoteDefHandler: TokenizerStrategy = {
-    name: "FootnoteDef",
+    type: "FootnoteDef",
     match: (lex) => lex.isStartOfLine() && /^\[\^[^\]]+\]:/.test(lex.peekUntil("\n")),
     emit: (lex) => {
         const line = lex.readUntil("\n")
@@ -101,7 +100,7 @@ const FootnoteDefHandler: TokenizerStrategy = {
     }
 }
 const FootnoteRefHandler: TokenizerStrategy = {
-    name: "FootnoteRef",
+    type: "FootnoteRef",
     match: (lex) => lex.startsWith("[^"),
     emit: (lex) => {
         lex.next(2) //Skip [^
@@ -112,22 +111,22 @@ const FootnoteRefHandler: TokenizerStrategy = {
 
 //List
 const TaskListHandler: TokenizerStrategy = {
-    name: "TaskList",
+    type: "TaskList",
     match: (lex) => lex.isStartOfLine() && /^(\s*)([-*+]) \[( |x|X)\] /.test(lex.peekUntil("\n")),
     emit: (lex) => utils.handleList(lex, false, true)
 }
 const UnorderedListHandler: TokenizerStrategy = {
-    name: "UnorderList",
+    type: "UnorderList",
     match: (lex) => lex.isStartOfLine() && /^(\s*)([-*+]) /.test(lex.peekUntil("\n")),
     emit: (lex) => utils.handleList(lex, false, false)
 }
 const OrderedListHandler: TokenizerStrategy = {
-    name: "OrderedList",
+    type: "OrderedList",
     match: (lex) => lex.isStartOfLine() && /^(\s*)(\d+)\. /.test(lex.peekUntil("\n")),
     emit: (lex) => utils.handleList(lex, true, false)
 }
 const EndListHandler: TokenizerStrategy = {
-    name: "EndList",
+    type: "EndList",
     match: (lex) => lex.listLevelFlag > 0 && lex.isStartOfLine() && !/^(\s*)([-+*]|\d+\.) /.test(lex.peekUntil("\n")),
     emit: (lex) => {
         while (lex.listLevelFlag > 0) {
@@ -138,14 +137,14 @@ const EndListHandler: TokenizerStrategy = {
 
 //Table
 const TableHandler: TokenizerStrategy = {
-    name: "Table",
+    type: "Table",
     match: (lex) => lex.isStartOfLine() && /^\s*\|.*\|\s*$/.test(lex.peekUntil("\n")),
     emit: (lex) => utils.handleTable(lex)
 }
 
 //Other common syntax
 const InlineCodeHandler: TokenizerStrategy = {
-    name: "InlineCode",
+    type: "InlineCode",
     match: (lex) => lex.peek() === "`",
     emit: (lex) => {
         let content = ""
@@ -160,7 +159,7 @@ const InlineCodeHandler: TokenizerStrategy = {
 }
 
 const HeaderHandler: TokenizerStrategy = {
-    name: "Header",
+    type: "Header",
     match: (lex) => lex.peek() === "#",
     emit: (lex) => {
         let level = 0
@@ -180,7 +179,7 @@ const HeaderHandler: TokenizerStrategy = {
 }
 
 const ItalicHandler: TokenizerStrategy = {
-    name: "Italic",
+    type: "Italic",
     match: (lex) => lex.peek() === "*" || lex.peek() === "_",
     emit: (lex) => {
         lex.listToken.push({ type: "Italic" })
@@ -188,7 +187,7 @@ const ItalicHandler: TokenizerStrategy = {
 }
 
 const QuoteHandler: TokenizerStrategy = {
-    name: "Quote",
+    type: "Quote",
     match: (lex) => lex.peek() === ">",
     emit: (lex) => {
         lex.listToken.push({ type: "Quote" })
@@ -196,7 +195,7 @@ const QuoteHandler: TokenizerStrategy = {
 }
 
 const LinkHandler: TokenizerStrategy = {
-    name: "Link",
+    type: "Link",
     match: (lex) => lex.peek() === "[",
     emit: (lex) => {
         lex.next() //Skip [
@@ -214,7 +213,7 @@ const LinkHandler: TokenizerStrategy = {
 }
 
 const ImageHandler: TokenizerStrategy = {
-    name: "Image",
+    type: "Image",
     match: (lex) => lex.peek() === "!" && lex.peek(1) === "[",
     emit: (lex) => {
         lex.next() //Skip !
@@ -235,7 +234,7 @@ const ImageHandler: TokenizerStrategy = {
 }
 
 const NewLineHandler: TokenizerStrategy = {
-    name: "NewLine",
+    type: "NewLine",
     match: (lex) => lex.peek() === "\n",
     emit: (lex) => {
         lex.listToken.push({ type: "NewLine" })

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,18 +37,34 @@ export function convertMarkdownToHTML(
         renderOptions: {},
         converterOptions: { allowDangerousHtml: false }
     },
-    plugin: MarkdownPlugin<string>[] = []
+    plugin: MarkdownPlugin<string, string>[] = []
 ): string {
     return new DefaultMarkdownConverter(options, plugin).convert(input)
 }
 
+/**
+ * Default Markdown converter that outputs a standard HTML string
+ * @extends BaseConverter<string>
+ * @example
+ * ```ts
+ * const converter = new DefaultMarkdownConverter(
+ *  { 
+ *    renderOptions: { 
+ *      className: { Header: "my-title" } 
+ *    }
+ *  }, 
+ *  [MyCustomPlugin]
+ * );
+ * const html = converter.convert("# Hello");
+ * ```
+ */
 export class DefaultMarkdownConverter extends BaseConverter<string> {
     constructor(
         options: MarkdownOptions<string> = {
             renderOptions: {},
             converterOptions: { allowDangerousHtml: false }
         },
-        plugin: MarkdownPlugin<string>[] = []
+        plugin: MarkdownPlugin<string, string>[] = []
     ) {
         super(options, plugin)
     }

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -1,15 +1,17 @@
 import React from "react"
-import Lexer from "./core/lexer"
-import { Parser } from "./core/parser"
-import { FootnoteResolver } from "./core/resolver/footnote-resolver"
 import { ReactRenderer } from "./renderers/react"
 import { MarkdownOptions } from "./types/options"
+import { BaseConverter } from "./types/converter"
+import { MarkdownPlugin } from "./types/plugin"
+
+export { ReactRenderer }
 
 /**
  * Convert a Markdown string into a ReactNode.
  * @param input - The Markdown source string
  * @param renderOptions - Optional rendering options
  * @param options - Optional handle options
+ * @param [plugin=[]] - Optional plugin for additional render rules
  * @returns The rendered `React.ReactNode` ready to be rendered into a React component.
  * 
  * @example
@@ -23,11 +25,10 @@ export function convertMarkdownToReactNode(
     options: MarkdownOptions<React.ReactNode> = {
         renderOptions: {},
         converterOptions: { allowDangerousHtml: false }
-    }): React.ReactNode {
-    const tokens = new Lexer(input).tokenize()
-    const footNoteResolver = new FootnoteResolver()
-    const nodes = new Parser(tokens, footNoteResolver).parse()
-    return new ReactRenderer(footNoteResolver, options).render(nodes)
+    },
+    plugin: MarkdownPlugin<React.ReactNode>[] = []
+): React.ReactNode {
+    return new ReactMarkdownConverter(options, plugin).convert(input)
 }
 
 /**
@@ -48,11 +49,38 @@ export function convertMarkdownToReactNode(
 export const MarkdownComponent: React.FC<{
     content: string,
     options?: MarkdownOptions<React.ReactNode>
-    className?: string
-}> = ({ content, className, options }) => {
+    className?: string,
+    plugin?: MarkdownPlugin<React.ReactNode>[]
+}> = ({ content, className, options, plugin }) => {
     const rendered = React.useMemo(() => {
-        return convertMarkdownToReactNode(content, options)
-    }, [content])
+        return new ReactMarkdownConverter(options, plugin).convert(content)
+    }, [content, options, plugin])
 
     return React.createElement("div", { className }, rendered)
+}
+
+/**
+ * 
+ */
+export class ReactMarkdownConverter extends BaseConverter<React.ReactNode> {
+    constructor(
+        options: MarkdownOptions<React.ReactNode> = {
+            renderOptions: {},
+            converterOptions: { allowDangerousHtml: false }
+        },
+        plugin: MarkdownPlugin<React.ReactNode>[] = []
+    ) {
+        super(options, plugin)
+    }
+
+    convert(input: string): React.ReactNode {
+        const tokens = this.getTokens(input)
+        const nodes = this.getNodes(tokens)
+        const renderer = new ReactRenderer(
+            this.footnoteResolver,
+            this.options,
+            this.plugin.map(p => p.renderer)
+        )
+        return renderer.render(nodes)
+    }
 }

--- a/src/react.tsx
+++ b/src/react.tsx
@@ -26,7 +26,7 @@ export function convertMarkdownToReactNode(
         renderOptions: {},
         converterOptions: { allowDangerousHtml: false }
     },
-    plugin: MarkdownPlugin<React.ReactNode>[] = []
+    plugin: MarkdownPlugin<string, React.ReactNode>[] = []
 ): React.ReactNode {
     return new ReactMarkdownConverter(options, plugin).convert(input)
 }
@@ -37,6 +37,7 @@ export function convertMarkdownToReactNode(
  * @param props.content - The Markdown source to render.
  * @param props.options - Optional configuration for the renderer. 
  * @param props.className - Optional CSS classes for the wrapping `div` element.
+ * @param props.plugin - Optional plugin for additional syntax handler.
  * @example
  * ```tsx
  * <MarkdownComponent
@@ -50,7 +51,7 @@ export const MarkdownComponent: React.FC<{
     content: string,
     options?: MarkdownOptions<React.ReactNode>
     className?: string,
-    plugin?: MarkdownPlugin<React.ReactNode>[]
+    plugin?: MarkdownPlugin<string, React.ReactNode>[]
 }> = ({ content, className, options, plugin }) => {
     const rendered = React.useMemo(() => {
         return new ReactMarkdownConverter(options, plugin).convert(content)
@@ -60,7 +61,20 @@ export const MarkdownComponent: React.FC<{
 }
 
 /**
- * 
+ * React Markdown converter that outputs a React.ReactNode
+ * @extends BaseConverter<React.ReactNode>
+ * @example
+ * ```ts
+ * const converter = new ReactMarkdownConverter(
+ *  { 
+ *    renderOptions: { 
+ *      className: { Header: "my-title" } 
+ *    }
+ *  }, 
+ *  [MyCustomPlugin]
+ * );
+ * const html = converter.convert("# Hello");
+ * ```
  */
 export class ReactMarkdownConverter extends BaseConverter<React.ReactNode> {
     constructor(
@@ -68,7 +82,7 @@ export class ReactMarkdownConverter extends BaseConverter<React.ReactNode> {
             renderOptions: {},
             converterOptions: { allowDangerousHtml: false }
         },
-        plugin: MarkdownPlugin<React.ReactNode>[] = []
+        plugin: MarkdownPlugin<string, React.ReactNode>[] = []
     ) {
         super(options, plugin)
     }

--- a/src/renderers/default/index.ts
+++ b/src/renderers/default/index.ts
@@ -10,13 +10,15 @@ export class DefaultRenderer implements IRenderer<string> {
     options: MarkdownOptions<string>
     footnoteResolver: FootnoteResolver
 
-    private strategies: Map<string, RenderStrategy<string>> = new Map()
+    strategies: Map<string, RenderStrategy<string>> = new Map()
 
-    constructor(footnoteResolver: FootnoteResolver, options: MarkdownOptions<string> = {}) {
+    constructor(footnoteResolver: FootnoteResolver, options: MarkdownOptions<string> = {}, plugin: RenderStrategy<string>[] = []) {
         this.footnoteResolver = footnoteResolver;
         this.options = options;
         this.registerDefaultStrategies();
+        if (plugin.length > 0) plugin.forEach(p => this.registerStrategy(p))
     }
+    
 
     private registerDefaultStrategies() {
         const listDefaultStrategy = [
@@ -96,5 +98,9 @@ export class DefaultRenderer implements IRenderer<string> {
             return `<table${cls ? ` class="${cls}"` : ""}>${tHead}${tBody}</table>`
         }
         else return `<p${cls ? ` class="${cls}"` : ""}>${children.join("\n")}</p>`
+    }
+
+    registerStrategy(strategy: RenderStrategy<string>): void {
+        this.strategies.set(strategy.type, strategy)
     }
 }

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -1,12 +1,15 @@
 import { ASTNode } from "../types/parser";
 import { MarkdownOptions } from '../types/options/index'
 import { FootnoteResolver } from "../core/resolver/footnote-resolver";
+import { RenderStrategy } from "../types/renderer";
 
 export interface IRenderer<TOutput> {
     options: MarkdownOptions<TOutput>
     footnoteResolver: FootnoteResolver
+    strategies: Map<string, RenderStrategy<TOutput>>
 
     render(node: ASTNode): TOutput
     renderTable(node: ASTNode, children: TOutput[]): TOutput
     renderFootnotes(): TOutput
+    registerStrategy(strategy: RenderStrategy<TOutput>): void
 }

--- a/src/renderers/react/index.ts
+++ b/src/renderers/react/index.ts
@@ -11,12 +11,13 @@ export class ReactRenderer implements IRenderer<React.ReactNode> {
     options: MarkdownOptions<React.ReactNode>
     footnoteResolver: FootnoteResolver
 
-    private strategies: Map<string, RenderStrategy<React.ReactNode>> = new Map()
+    strategies: Map<string, RenderStrategy<React.ReactNode>> = new Map()
 
-    constructor(footnoteResolver: FootnoteResolver, options: MarkdownOptions<React.ReactNode> = {}) {
+    constructor(footnoteResolver: FootnoteResolver, options: MarkdownOptions<React.ReactNode> = {}, plugin: RenderStrategy<React.ReactNode>[] = []) {
         this.footnoteResolver = footnoteResolver;
         this.options = options;
         this.registerDefaultStrategies();
+        if (plugin.length > 0) plugin.forEach(p => this.registerStrategy(p))
     }
 
     private registerDefaultStrategies() {
@@ -142,5 +143,9 @@ export class ReactRenderer implements IRenderer<React.ReactNode> {
             )
         }
         else return React.createElement("p", { className: getClassName(this, node), }, ...children)
+    }
+
+    registerStrategy(strategy: RenderStrategy<React.ReactNode>): void {
+        this.strategies.set(strategy.type, strategy)
     }
 }

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -1,4 +1,4 @@
-import Lexer from "../core/lexer";
+import { Lexer } from "../core/lexer";
 import { Parser } from "../core/parser";
 import { FootnoteResolver } from "../core/resolver/footnote-resolver";
 import { MarkdownOptions } from "./options";
@@ -11,7 +11,7 @@ export abstract class BaseConverter<TOutput> {
 
     constructor(
         protected options: MarkdownOptions<TOutput>,
-        protected plugin: MarkdownPlugin<TOutput>[]
+        protected plugin: MarkdownPlugin<string, TOutput>[]
     ) {
         this.footnoteResolver = new FootnoteResolver()
     }

--- a/src/types/converter.ts
+++ b/src/types/converter.ts
@@ -1,0 +1,35 @@
+import Lexer from "../core/lexer";
+import { Parser } from "../core/parser";
+import { FootnoteResolver } from "../core/resolver/footnote-resolver";
+import { MarkdownOptions } from "./options";
+import { ASTNode } from "./parser";
+import { MarkdownPlugin } from "./plugin";
+import { Token } from "./token";
+
+export abstract class BaseConverter<TOutput> {
+    protected footnoteResolver: FootnoteResolver
+
+    constructor(
+        protected options: MarkdownOptions<TOutput>,
+        protected plugin: MarkdownPlugin<TOutput>[]
+    ) {
+        this.footnoteResolver = new FootnoteResolver()
+    }
+
+    protected getTokens(input: string): Token[] {
+        return new Lexer(input, this.plugin.map(p => p.tokenizer)).tokenize()
+    }
+
+    protected getNodes(tokens: Token[]): ASTNode {
+        return new Parser(
+            tokens,
+            this.footnoteResolver,
+            this.plugin.map(p => ({
+                type: p.type,
+                strategy: p.parser
+            }))
+        ).parse()
+    }
+
+    abstract convert(input: string): TOutput
+}

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -2,20 +2,64 @@ import { TokenizerStrategy } from "./token";
 import { NodeType, ParsingStrategy } from "./parser"
 import { RenderStrategy } from "./renderer";
 
-export interface MarkdownPlugin<TOutput> {
-    name: string
+/**
+ * Representing a custom plugin for the Markdown converter.
+ * It allow to define new syntax by hooking into the `Lexing`, `Parsing` and `Rendering` stages.
+ * @template TOutput - The type of final rendered output
+ */
+export interface MarkdownPlugin<T extends string, TOutput> {
+    /**
+     * Unique identifier for the plugin
+     */
+    name: T
+    /**
+     * Define the context of plugin
+     */
     type: "block" | "inline"
-    tokenizer: TokenizerStrategy,
-    parser: ParsingStrategy
-    renderer: RenderStrategy<TOutput>
+    /**
+     * Strategy for the Lexer.
+     * The `type` property of this property must be same as `name` property
+     */
+    tokenizer: TokenizerStrategy & { type: T },
+    /**
+     * Strategy for the Parser.
+     * The `type` property of this property must be same as `name` property
+     */
+    parser: ParsingStrategy & { type: T }
+    /**
+     * Strategy for the Renderer.
+     * The `type` property of this property must be same as `name` property
+     */
+    renderer: RenderStrategy<TOutput> & { type: T }
 }
 
-export function createPlugin<TOutput>(name: string, type: "block" | "inline", tokenizer: TokenizerStrategy, parser: ParsingStrategy, renderer: RenderStrategy<TOutput>): MarkdownPlugin<TOutput> {
+/**
+ * A helper function to create a plugin
+ * @template T - The literal string type for the plugin name.
+ * @template TOutput - The output type.
+ * @param name - Name of plugin
+ * @param type - Context of plugin, determine for parser processing
+ * @param tokenizer - Tokenizer strategy for Lexer
+ * @param parser - Parser strategy for Parser
+ * @param renderer - Render strategy for Renderer
+ * @returns - A complete Markdown plugin
+ */
+export function createPlugin<T extends string, TOutput>(
+    name: T,
+    type: "block" | "inline",
+    tokenizer: Omit<TokenizerStrategy, "type">,
+    parser: Omit<ParsingStrategy, "type">,
+    renderer: Omit<RenderStrategy<TOutput>, "type">
+): MarkdownPlugin<T, TOutput> {
+    const finalTokenizer = Object.assign(tokenizer, { type: name }) as TokenizerStrategy & { type: T }
+    const finalParser = Object.assign(parser, { type: name }) as ParsingStrategy & { type: T }
+    const finalRenderer = Object.assign(renderer, { type: name }) as RenderStrategy<TOutput> & { type: T }
+
     return {
         name,
         type,
-        tokenizer,
-        parser,
-        renderer
+        tokenizer: finalTokenizer,
+        parser: finalParser,
+        renderer: finalRenderer
     }
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,0 +1,21 @@
+import { TokenizerStrategy } from "./token";
+import { NodeType, ParsingStrategy } from "./parser"
+import { RenderStrategy } from "./renderer";
+
+export interface MarkdownPlugin<TOutput> {
+    name: string
+    type: "block" | "inline"
+    tokenizer: TokenizerStrategy,
+    parser: ParsingStrategy
+    renderer: RenderStrategy<TOutput>
+}
+
+export function createPlugin<TOutput>(name: string, type: "block" | "inline", tokenizer: TokenizerStrategy, parser: ParsingStrategy, renderer: RenderStrategy<TOutput>): MarkdownPlugin<TOutput> {
+    return {
+        name,
+        type,
+        tokenizer,
+        parser,
+        renderer
+    }
+}

--- a/src/types/token.ts
+++ b/src/types/token.ts
@@ -158,7 +158,7 @@ export interface Token {
  * @property emit - A function handle tokenizing input to `Token`.
  */
 export interface TokenizerStrategy {
-    name: string
+    type: string
     /**
      * Checks if the current cursor position in the Lexer matches this syntax
      * @param lex The current `ILexer` instance providing access to the input string and cursor.

--- a/src/utilities/tokenizer-utils.ts
+++ b/src/utilities/tokenizer-utils.ts
@@ -1,4 +1,4 @@
-import Lexer, { ILexer } from "../core/lexer"
+import { Lexer, ILexer } from "../core/lexer"
 import { Token } from "../types/token"
 
 function handleTextBlock(lex: ILexer) {

--- a/test/lexer.test.ts
+++ b/test/lexer.test.ts
@@ -1,4 +1,4 @@
-import Lexer from "../src/core/lexer"
+import { Lexer } from "../src/core/lexer"
 
 describe("Lexer", () => {
     test("Tokenize plain text", () => {

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { convertMarkdownToHTML } from "../src/index";
+import { convertMarkdownToHTML, MarkdownPlugin } from "../src/index";
 import { RenderOption } from "../src/types/options/renderOptions";
 
 describe("Test a whole markdown", () => {
@@ -93,10 +93,44 @@ describe("Test a whole markdown", () => {
         const md = "# Title\nParagraph content";
         const result = convertMarkdownToHTML(md, { renderOptions });
 
-        const expected = 
+        const expected =
             '<h1 class="main-title" style="border-bottom: 1px solid #d1d9e0b3">Title</h1>' +
             '<p class="text-muted">Paragraph content</p>';
 
         expect(result).toBe(expected);
+    })
+
+    test("Plugin system: Custom Emoji (:omg:)", () => {
+        const emojiPlugin: MarkdownPlugin<string> = {
+            name: "Emoji",
+            type: "inline",
+            tokenizer: {
+                name: "Emoji",
+                match: (lexer) => lexer.peek() === ":",
+                emit: (lexer) => {
+                    lexer.next()
+                    lexer.listToken.push({ type: "Emoji", value: lexer.readUntil(":") })
+                }
+            },
+            parser: {
+                type: "Emoji",
+                execute: (parser, token) => {
+                    parser.next(1)
+                    return { type: "Emoji", value: token.value };
+                }
+            },
+            renderer: {
+                type: "Emoji",
+                render: (node) => {
+                    return `<span class="emoji emoji-${node.value}">😲</span>`;
+                }
+            }
+        };
+
+        const md = "Hello :omg: world";
+
+        const result = convertMarkdownToHTML(md, undefined, [emojiPlugin]);
+
+        expect(result).toBe('<p>Hello <span class="emoji emoji-omg">😲</span> world</p>');
     })
 })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -101,11 +101,11 @@ describe("Test a whole markdown", () => {
     })
 
     test("Plugin system: Custom Emoji (:omg:)", () => {
-        const emojiPlugin: MarkdownPlugin<string> = {
+        const emojiPlugin: MarkdownPlugin<string, string> = {
             name: "Emoji",
             type: "inline",
             tokenizer: {
-                name: "Emoji",
+                type: "Emoji",
                 match: (lexer) => lexer.peek() === ":",
                 emit: (lexer) => {
                     lexer.next()

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,7 +1,7 @@
 import { Parser } from "../src/core/parser";
 import { Token } from "../src/types/token";
 import { ASTNode } from "../src/types/parser";
-import Lexer from "../src/core/lexer";
+import { Lexer } from "../src/core/lexer";
 import { FootnoteResolver } from "../src/core/resolver/footnote-resolver";
 
 describe("Parser", () => {
@@ -129,7 +129,7 @@ describe("Parser", () => {
         const md = "| Name  | Age |\n|-------|----:|\n| Alice |  24 |\n| Bob   |  30 |";
         const tokens = new Lexer(md).tokenize();
         const parser = new Parser(tokens, new FootnoteResolver());
-        
+
         expect(parser.parse()).toEqual<ASTNode>({
             type: "Document",
             children: [{


### PR DESCRIPTION
Release v1.3.0 focuses on making custom new syntax rules available.

## Key changes
- **Additional Plugin:** Add plugin for creating new syntax rules from `lexer`, `parser` to `renderer`
- **Output Class:** Add `DefaultMarkdownConverter` and `ReactMarkdownConverter` class for better usage.

## Testing
- Add new test for custom plugin feature.
- Passed all test case included new test cases